### PR TITLE
[Fix] 마이페이지 응답에 프로필 이미지 대신 이메일 반환

### DIFF
--- a/src/main/java/ChickenMayoDeopbab/bada/domain/user/dto/response/MyPageResponse.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/user/dto/response/MyPageResponse.java
@@ -2,9 +2,9 @@ package ChickenMayoDeopbab.bada.domain.user.dto.response;
 
 public record MyPageResponse(
         String username,
-        String profileImage
+        String email
 ) {
-    public static MyPageResponse of(String username, String profileImage) {
-        return new MyPageResponse(username, profileImage);
+    public static MyPageResponse of(String username, String email) {
+        return new MyPageResponse(username, email);
     }
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/user/service/UserService.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/user/service/UserService.java
@@ -39,7 +39,7 @@ public class UserService {
         Users user = usersRepository.findByUsername(auth.getName())
                 .orElseThrow(() -> new ApplicationException(UsersStatusCode.USER_NOT_FOUND));
 
-        return ApiResponse.ok(MyPageResponse.of(user.getUsername(), user.getProfileImage()));
+        return ApiResponse.ok(MyPageResponse.of(user.getUsername(), user.getEmail()));
     }
 
     //  아이디 검증 및 이메일인 중복 검사


### PR DESCRIPTION
## 변경 사항
- `MyPageResponse`의 `profileImage` 필드를 `email`로 변경
- `UserService`에서 마이페이지 응답 생성 시 `user.getProfileImage()` 대신 `user.getEmail()`을 사용하도록 수정

## 변경 이유
- 마이페이지에서 프로필 이미지가 아닌 사용자 이메일을 노출해야 하는 요구사항 반영

## 테스트 방법
1. 로그인 후 마이페이지 조회 API 호출
2. 응답 본문에 `username`과 `email`이 정상적으로 내려오는지 확인

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)