### PR TITLE
[Chore] docker-compose app 서비스에 build 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
     restart: unless-stopped
 
   app:
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: ehdus/bada:latest
     ports:
       - "8080:8080"


### PR DESCRIPTION
## 변경 사항
- `docker-compose.yml`의 `app` 서비스에 `build` 설정 추가
  - `context: .`
  - `dockerfile: Dockerfile`

## 변경 이유
- 기존에는 `image: ehdus/bada:latest` 이미지만 사용하여, 로컬 소스 코드 변경 사항을 직접 빌드해 반영할 수 없었습니다.
- `build` 설정을 추가하여 로컬 Dockerfile 기반으로 이미지를 빌드할 수 있도록 합니다.