### PR TITLE
[Feature] 피드백 응답에 good_point, sessionType 추가

### DIFF
--- a/src/main/java/ChickenMayoDeopbab/bada/domain/session/model/GoodSegment.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/session/model/GoodSegment.java
@@ -1,5 +1,7 @@
 package ChickenMayoDeopbab.bada.domain.session.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 // FastAPI가 전달하는 잘한 발화 구간(초 단위)
-public record GoodSegment(Double start, Double end) {
+public record GoodSegment(Double start, Double end, @JsonProperty("good_point") String goodPoint) {
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/dto/response/FeedbackResponse.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/dto/response/FeedbackResponse.java
@@ -1,5 +1,6 @@
 package ChickenMayoDeopbab.bada.domain.trainingrecord.dto.response;
 
+import ChickenMayoDeopbab.bada.domain.session.enums.SessionType;
 import ChickenMayoDeopbab.bada.domain.session.model.GoodSegment;
 import ChickenMayoDeopbab.bada.domain.trainingrecord.entity.TrainingRecord;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -9,6 +10,7 @@ import java.time.LocalTime;
 import java.util.List;
 
 public record FeedbackResponse(
+        SessionType sessionType,
         String scenarioName,
         @JsonFormat(pattern = "HH:mm:ss")
         LocalTime trainingTime,
@@ -17,6 +19,7 @@ public record FeedbackResponse(
 ) {
     public static FeedbackResponse of(TrainingRecord trainingRecord, List<GoodSegment> goodSegments) {
         return new FeedbackResponse(
+                trainingRecord.getSessionType(),
                 trainingRecord.getScenarioName(),
                 LocalTime.ofSecondOfDay
                         (Duration.between(trainingRecord.getStartedAt(), trainingRecord.getEndedAt()).getSeconds()),

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/dto/response/PositiveFeedbackResponse.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/dto/response/PositiveFeedbackResponse.java
@@ -5,6 +5,7 @@ import ChickenMayoDeopbab.bada.domain.session.model.GoodSegment;
 public record PositiveFeedbackResponse(
         Double startSecond,
         Double endSecond,
+        String good_point,
         String summary,
         String audioUrl
 ) {
@@ -12,6 +13,7 @@ public record PositiveFeedbackResponse(
         return new PositiveFeedbackResponse(
                 segment.start(),
                 segment.end(),
+                segment.goodPoint(),
                 null,
                 null
         );


### PR DESCRIPTION
## 변경 사항
- `PositiveFeedbackResponse`에 `good_point` 필드 추가 (FastAPI가 전달하는 잘한 발화 구간의 코멘트)
- `GoodSegment` record에 `good_point`(goodPoint) 필드 추가
- `FeedbackResponse`에 `sessionType` 필드 추가

## 변경 이유
- 피드백 조회 시 잘한 점(good_point)과 세션 타입(sessionType) 정보를 클라이언트에 함께 내려주기 위함 (#58)

## 테스트 방법
- 피드백 조회 API 호출 시 응답에 `sessionType`, `good_point` 필드가 정상 포함되는지 확인

closes #58