### PR TITLE
[Refactor] S3 인증을 AWS SDK v2 IAM Role 방식으로 이관

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,8 +65,9 @@ dependencies {
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
-	// AWS S3
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	// AWS S3 (SDK v2 — IAM Role/DefaultCredentialsProvider)
+	implementation platform('software.amazon.awssdk:bom:2.28.0')
+	implementation 'software.amazon.awssdk:s3'
 }
 
 tasks.named('test') {

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/file/service/FileService.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/file/service/FileService.java
@@ -6,19 +6,21 @@ import ChickenMayoDeopbab.bada.domain.file.enumeration.FileType;
 import ChickenMayoDeopbab.bada.domain.file.exception.FileStatusCode;
 import ChickenMayoDeopbab.bada.domain.file.repository.FileRepository;
 import ChickenMayoDeopbab.bada.global.exception.ApplicationException;
-import com.amazonaws.HttpMethod;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Date;
 import java.util.UUID;
 
 @Service
@@ -26,10 +28,11 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class FileService {
 
-    private final AmazonS3Client amazonS3Client;
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
     private final FileRepository fileRepository;
 
-    @Value("${spring.cloud.aws.s3.bucket}")
+    @Value("${aws.s3.bucket}")
     private String bucket;
 
     private static final Duration PRESIGNED_URL_EXPIRATION = Duration.ofMinutes(10);
@@ -64,28 +67,38 @@ public class FileService {
     public void delete(Long fileId) {
         File file = fileRepository.findById(fileId)
                 .orElseThrow(() -> ApplicationException.of(FileStatusCode.FILE_NOT_FOUND));
-        amazonS3Client.deleteObject(bucket, file.getS3Key());
+        s3Client.deleteObject(DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(file.getS3Key())
+                .build());
         fileRepository.delete(file);
     }
 
     private String generatePresignedUrl(String s3Key) {
-        Date expiration = new Date(System.currentTimeMillis() + PRESIGNED_URL_EXPIRATION.toMillis());
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3Key)
+                .build();
 
-        GeneratePresignedUrlRequest request =
-                new GeneratePresignedUrlRequest(bucket, s3Key)
-                        .withMethod(HttpMethod.GET)
-                        .withExpiration(expiration);
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(PRESIGNED_URL_EXPIRATION)
+                .getObjectRequest(getObjectRequest)
+                .build();
 
-        return amazonS3Client.generatePresignedUrl(request).toString();
+        return s3Presigner.presignGetObject(presignRequest).url().toString();
     }
 
     private void putObject(MultipartFile multipartFile, String s3Key) {
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentType(multipartFile.getContentType());
-        metadata.setContentLength(multipartFile.getSize());
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3Key)
+                .contentType(multipartFile.getContentType())
+                .contentLength(multipartFile.getSize())
+                .build();
 
         try {
-            amazonS3Client.putObject(bucket, s3Key, multipartFile.getInputStream(), metadata);
+            s3Client.putObject(request,
+                    RequestBody.fromInputStream(multipartFile.getInputStream(), multipartFile.getSize()));
         } catch (IOException e) {
             throw ApplicationException.of(FileStatusCode.FILE_UPLOAD_FAILED, e);
         }

--- a/src/main/java/ChickenMayoDeopbab/bada/global/config/S3Config.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/global/config/S3Config.java
@@ -1,29 +1,31 @@
 package ChickenMayoDeopbab.bada.global.config;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
-    @Value("${spring.cloud.aws.credentials.access-key}")
-    private String accessKey;
-    @Value("${spring.cloud.aws.credentials.secret-key}")
-    private String secretKey;
-    @Value("${spring.cloud.aws.region.static}")
+    @Value("${aws.region}")
     private String region;
 
     @Bean
-    public AmazonS3Client amazonS3Client() {
-        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
 
-        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
-                .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -72,15 +72,10 @@ spring:
   openai:
     api-key: ${OPENAI-API-KEY}
 
-  cloud:
-    aws:
-      credentials:
-        access-key: ${AWS_ACCESS_KEY}
-        secret-key: ${AWS_SECRET_KEY}
-      region:
-        static: ap-northeast-2
-      s3:
-        bucket: ${BUCKET_NAME}
+aws:
+  region: ap-northeast-2
+  s3:
+    bucket: ${BUCKET_NAME}
 
 app:
   jwt:


### PR DESCRIPTION
## 변경 사항
- S3 클라이언트를 **AWS SDK v1(`spring-cloud-starter-aws:2.2.6`) → SDK v2(`software.amazon.awssdk:s3`)** 로 이관
- 인증을 하드코딩 키 방식 → **`DefaultCredentialsProvider`(EC2 IAM Role 자동 인식)** 로 변경
- `S3Config`: `AmazonS3Client` → `S3Client` + `S3Presigner` 빈
- `FileService`: `putObject`/presigned URL/`delete` 내부를 v2 API로 재작성 (메서드 시그니처·업로드 로직은 동일)
- `application.yaml`: `spring.cloud.aws.*` → 최상위 `aws.*` (accessKey/secretKey 제거, region·bucket만 유지)

## 변경 이유
- accessKey/secretKey 발급이 막혀 있어 EC2 IAM Role 방식이 요구됨
- 기존 SDK v1(2020, EOL)이 Spring Boot 3.4.5의 Jackson 2.18과 충돌 (`EC2MetadataUtils`가 삭제된 `PASCAL_CASE_TO_CAMEL_CASE` 참조) → Role 자격증명 로딩 시 `NoSuchFieldError` 발생
- SDK v2로 이관하면 Jackson 충돌이 사라지고, 코드에 키를 넣지 않아도 EC2에서 Role로 자동 인증됨

## 테스트 방법
1. EC2(IAM Role `SafeInstanceProfile-*` 연결)에 배포
2. 파일 업로드 트리거 → S3 업로드 및 presigned URL 발급 정상 확인
3. 반환된 presigned URL로 객체 조회(GetObject) 확인

## ⚠️ 검증 상태
- 컴파일 통과 확인 완료
- **로컬 검증은 불가**: IMDS(인스턴스 메타데이터)는 EC2에서만 동작하므로 로컬에서는 credential 로딩이 실패하는 것이 정상
- **실제 S3 동작 검증은 EC2 배포 후 필요** (미완료)

Closes #64
