### PR TITLE
[Fix] 예약 발신 스케줄러 트랜잭션 누락 수정

### DIFF
--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingcallschedule/service/TrainingCallScheduleTriggerService.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingcallschedule/service/TrainingCallScheduleTriggerService.java
@@ -28,6 +28,7 @@ public class TrainingCallScheduleTriggerService {
     private final JwtProvider jwtProvider;
 
     @Scheduled(fixedDelayString = "${app.training-call-schedule.trigger-fixed-delay-ms:30000}")
+    @Transactional
     public void triggerDueSchedules() {
         int triggeredCount = triggerDueSchedules(LocalDateTime.now());
         if (triggeredCount > 0) {


### PR DESCRIPTION
## 변경 사항
- `TrainingCallScheduleTriggerService`의 `@Scheduled` 진입점 메서드(`triggerDueSchedules()`)에 `@Transactional` 추가

## 변경 이유
스케줄러가 30초마다 실행될 때마다 `TransactionRequiredException`이 발생하고 있었습니다.

- `@Scheduled` 무인자 메서드가 같은 클래스의 `@Transactional` 오버로드(`triggerDueSchedules(LocalDateTime)`)를 **내부에서 `this`로 호출**
- 자기 호출(self-invocation)은 Spring 프록시를 거치지 않으므로 오버로드에 붙은 `@Transactional`이 무시됨
- 결국 트랜잭션 없이 JPA 조회가 실행되어 `Query requires transaction be in progress` 예외 발생

프록시가 실제로 가로채는 **스케줄러 진입점**에 트랜잭션을 걸어, 내부 호출까지 동일 트랜잭션에서 실행되도록 수정했습니다. 이로써 조회와 `schedule.markRinging(...)` dirty checking flush가 정상 동작합니다.

## 테스트 방법
- `./gradlew test --tests "*TrainingCallScheduleTriggerServiceTest*"`
- 앱 구동 후 스케줄러 실행 로그에서 `TransactionRequiredException`이 더 이상 발생하지 않는지 확인

Closes #66