### PR TITLE
[Feature] 녹음 파일을 S3 key로 저장하고 presigned URL로 제공

### DIFF
--- a/src/main/java/ChickenMayoDeopbab/bada/domain/file/service/FileService.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/file/service/FileService.java
@@ -74,7 +74,7 @@ public class FileService {
         fileRepository.delete(file);
     }
 
-    private String generatePresignedUrl(String s3Key) {
+    public String generatePresignedUrl(String s3Key) {
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucket)
                 .key(s3Key)

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/session/controller/InternalSessionController.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/session/controller/InternalSessionController.java
@@ -36,7 +36,7 @@ public class InternalSessionController {
                 request.silenceTotal(),
                 request.shakeCount(),
                 request.goodSegments(),
-                request.recordingUrl()
+                request.recordingKey()
         );
         return ApiResponse.ok("세션 종료가 처리되었습니다.");
     }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/session/dto/request/SessionClosedRequest.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/session/dto/request/SessionClosedRequest.java
@@ -17,7 +17,7 @@ public record SessionClosedRequest(
         Integer shakeCount,
         @JsonProperty("good_segments")
         List<GoodSegment> goodSegments,
-        @JsonProperty("recording_url")
-        String recordingUrl
+        @JsonProperty("recording_key")
+        String recordingKey
 ) {
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/session/port/LoggingSessionRecordAdapter.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/session/port/LoggingSessionRecordAdapter.java
@@ -24,12 +24,12 @@ public class LoggingSessionRecordAdapter implements SessionRecordPort {
             Double silenceTotal,
             Integer shakeCount,
             List<GoodSegment> goodSegments,
-            String recordingUrl
+            String recordingKey
     ) {
         Long userId = context != null ? context.userId() : null;
         int turns = transcript != null ? transcript.size() : 0;
         int goodSegmentCount = goodSegments != null ? goodSegments.size() : 0;
         log.info("세션 종료 기록 수신 sessionId={} userId={} reason={} turns={} silenceTotal={} shakeCount={} goodSegments={} hasRecording={}",
-                sessionId, userId, reason, turns, silenceTotal, shakeCount, goodSegmentCount, recordingUrl != null);
+                sessionId, userId, reason, turns, silenceTotal, shakeCount, goodSegmentCount, recordingKey != null);
     }
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/session/port/SessionRecordPort.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/session/port/SessionRecordPort.java
@@ -18,6 +18,6 @@ public interface SessionRecordPort {
             Double silenceTotal,
             Integer shakeCount,
             List<GoodSegment> goodSegments,
-            String recordingUrl
+            String recordingKey
     );
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/session/port/TrainingRecordSessionRecordAdapter.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/session/port/TrainingRecordSessionRecordAdapter.java
@@ -44,7 +44,7 @@ public class TrainingRecordSessionRecordAdapter implements SessionRecordPort {
             Double silenceTotal,
             Integer shakeCount,
             List<GoodSegment> goodSegments,
-            String recordingUrl
+            String recordingKey
     ) {
         if (trainingRecordRepository.existsBySessionId(sessionId)) {
             log.info("중복 세션 종료 기록 무시 sessionId={}", sessionId);
@@ -70,7 +70,7 @@ public class TrainingRecordSessionRecordAdapter implements SessionRecordPort {
                 .durationSeconds(Duration.between(startedAt, endedAt).toSeconds())
                 .transcript(toJson(transcript))
                 .goodSegments(toJson(goodSegments))
-                .recordingUrl(recordingUrl)
+                .recordingKey(recordingKey)
                 .build();
 
         trainingRecordRepository.save(record);

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/session/service/SessionService.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/session/service/SessionService.java
@@ -82,14 +82,14 @@ public class SessionService {
             Double silenceTotal,
             Integer shakeCount,
             List<GoodSegment> goodSegments,
-            String recordingUrl
+            String recordingKey
     ) {
         SessionContext context = sessionRedisRepository.find(sessionId);
         if (context == null) {
             log.warn("종료 콜백 - 세션 없음(만료/미존재) sessionId={} reason={}", sessionId, reason);
             return;
         }
-        sessionRecordPort.record(sessionId, context, reason, transcript, silenceTotal, shakeCount, goodSegments, recordingUrl);
+        sessionRecordPort.record(sessionId, context, reason, transcript, silenceTotal, shakeCount, goodSegments, recordingKey);
         sessionRedisRepository.delete(sessionId);
     }
 

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/dto/response/FeedbackResponse.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/dto/response/FeedbackResponse.java
@@ -17,14 +17,14 @@ public record FeedbackResponse(
         List<GoodSegment> goodSegments,
         String recordingUrl
 ) {
-    public static FeedbackResponse of(TrainingRecord trainingRecord, List<GoodSegment> goodSegments) {
+    public static FeedbackResponse of(TrainingRecord trainingRecord, List<GoodSegment> goodSegments, String recordingUrl) {
         return new FeedbackResponse(
                 trainingRecord.getSessionType(),
                 trainingRecord.getScenarioName(),
                 LocalTime.ofSecondOfDay
                         (Duration.between(trainingRecord.getStartedAt(), trainingRecord.getEndedAt()).getSeconds()),
                 goodSegments,
-                trainingRecord.getRecordingUrl()
+                recordingUrl
         );
     }
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/dto/response/TrainingRecordDetailResponse.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/dto/response/TrainingRecordDetailResponse.java
@@ -23,6 +23,7 @@ public record TrainingRecordDetailResponse(
 ) {
     public static TrainingRecordDetailResponse of(
             TrainingRecord record,
+            String recordingUrl,
             List<TranscriptTurn> transcript,
             List<PositiveFeedbackResponse> positiveFeedbacks
     ) {
@@ -35,7 +36,7 @@ public record TrainingRecordDetailResponse(
                 record.getSessionType(),
                 record.getAiPersonality(),
                 record.getDurationSeconds(),
-                record.getRecordingUrl(),
+                recordingUrl,
                 transcript,
                 positiveFeedbacks
         );

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/entity/TrainingRecord.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/entity/TrainingRecord.java
@@ -71,7 +71,7 @@ public class TrainingRecord {
     @Lob
     private String goodSegments;
 
-    private String recordingUrl;
+    private String recordingKey;
 
     @Builder
     private TrainingRecord(
@@ -87,7 +87,7 @@ public class TrainingRecord {
             Long durationSeconds,
             String transcript,
             String goodSegments,
-            String recordingUrl
+            String recordingKey
     ) {
         this.user = user;
         this.sessionId = sessionId;
@@ -101,6 +101,6 @@ public class TrainingRecord {
         this.durationSeconds = durationSeconds;
         this.transcript = transcript;
         this.goodSegments = goodSegments;
-        this.recordingUrl = recordingUrl;
+        this.recordingKey = recordingKey;
     }
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/service/TrainingRecordService.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/service/TrainingRecordService.java
@@ -1,5 +1,6 @@
 package ChickenMayoDeopbab.bada.domain.trainingrecord.service;
 
+import ChickenMayoDeopbab.bada.domain.file.service.FileService;
 import ChickenMayoDeopbab.bada.domain.session.model.GoodSegment;
 import ChickenMayoDeopbab.bada.domain.session.model.TranscriptTurn;
 import ChickenMayoDeopbab.bada.domain.trainingrecord.dto.response.FeedbackResponse;
@@ -33,6 +34,7 @@ public class TrainingRecordService {
     private final TrainingRecordRepository trainingRecordRepository;
     private final UsersRepository usersRepository;
     private final ObjectMapper objectMapper;
+    private final FileService fileService;
 
     public Page<TrainingRecordResponse> getTrainingRecords(Pageable pageable) {
         Users user = getUserInfo();
@@ -47,6 +49,7 @@ public class TrainingRecordService {
 
         return TrainingRecordDetailResponse.of(
                 record,
+                resolveRecordingUrl(record.getRecordingKey()),
                 parseTranscript(record.getTranscript()),
                 parseGoodSegments(record.getGoodSegments()).stream()
                         .map(PositiveFeedbackResponse::from)
@@ -61,8 +64,16 @@ public class TrainingRecordService {
 
         return FeedbackResponse.of(
                 trainingRecord,
-                parseGoodSegments(trainingRecord.getGoodSegments())
+                parseGoodSegments(trainingRecord.getGoodSegments()),
+                resolveRecordingUrl(trainingRecord.getRecordingKey())
         );
+    }
+
+    private String resolveRecordingUrl(String recordingKey) {
+        if (recordingKey == null || recordingKey.isBlank()) {
+            return null;
+        }
+        return fileService.generatePresignedUrl(recordingKey);
     }
 
     private Users getUserInfo() {


### PR DESCRIPTION
## 변경 사항
- `SessionClosedRequest`의 `recording_url` 필드를 `recording_key`로 변경 (세션 종료 콜백이 S3 key를 전달)
- `TrainingRecord` 엔티티의 `recordingUrl` 컬럼을 `recordingKey`로 변경하여 영구 URL 대신 S3 key를 저장
- `SessionRecordPort` 및 어댑터(`TrainingRecordSessionRecordAdapter`, `LoggingSessionRecordAdapter`) 시그니처를 `recordingKey` 기준으로 변경
- `FileService.generatePresignedUrl`을 `public`으로 열어 조회 시점에 presigned URL 생성
- `TrainingRecordService`에서 상세 조회/피드백 조회 시 `recordingKey`로 presigned URL을 생성해 `TrainingRecordDetailResponse`, `FeedbackResponse`에 담아 응답 (key가 없으면 `null` 반환)

## 변경 이유
- 기존에는 녹음 파일 URL을 DB에 그대로 저장했는데, presigned URL은 만료되므로 저장해두면 시간이 지나 접근이 불가능해집니다.
- S3 key를 저장하고 조회 시점마다 presigned URL을 새로 발급하면 항상 유효한 URL을 응답할 수 있습니다.

## 테스트 방법
1. 세션 종료 콜백(`POST /internal/sessions/closed`)을 `recording_key`에 S3 key를 담아 호출
2. `training_record` 테이블에 `recording_key` 컬럼으로 key가 저장되는지 확인
3. 훈련 기록 상세 조회 / 피드백 조회 API 호출 시 `recordingUrl`에 유효한 presigned URL이 내려오는지 확인
4. `recording_key`가 없는 기록 조회 시 `recordingUrl`이 `null`로 내려오는지 확인

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)