### PR TITLE
[Fix] 긍정 피드백 응답에 audioUrl 누락 수정

### DIFF
--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/dto/response/PositiveFeedbackResponse.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/dto/response/PositiveFeedbackResponse.java
@@ -9,13 +9,13 @@ public record PositiveFeedbackResponse(
         String summary,
         String audioUrl
 ) {
-    public static PositiveFeedbackResponse from(GoodSegment segment) {
+    public static PositiveFeedbackResponse from(GoodSegment segment, String audioUrl) {
         return new PositiveFeedbackResponse(
                 segment.start(),
                 segment.end(),
                 segment.goodPoint(),
                 null,
-                null
+                audioUrl
         );
     }
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/service/TrainingRecordService.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/service/TrainingRecordService.java
@@ -47,12 +47,13 @@ public class TrainingRecordService {
         TrainingRecord record = trainingRecordRepository.findByRecordIdAndUser(recordId, user)
                 .orElseThrow(() -> new ApplicationException(TrainingRecordStatusCode.RECORD_NOT_FOUND));
 
+        String recordingUrl = resolveRecordingUrl(record.getRecordingKey());
         return TrainingRecordDetailResponse.of(
                 record,
-                resolveRecordingUrl(record.getRecordingKey()),
+                recordingUrl,
                 parseTranscript(record.getTranscript()),
                 parseGoodSegments(record.getGoodSegments()).stream()
-                        .map(PositiveFeedbackResponse::from)
+                        .map(segment -> PositiveFeedbackResponse.from(segment, recordingUrl))
                         .toList()
         );
     }


### PR DESCRIPTION
## 작업 내용
- `PositiveFeedbackResponse.from`에 presigned URL(`audioUrl`) 파라미터 추가
- `TrainingRecordService.getTrainingRecord`에서 presigned URL을 한 번만 생성해 상세 응답과 각 긍정 피드백 항목에 전달

## 참고
- PR #70 머지 이후 발견된 후속 수정입니다 (긍정 피드백의 `audioUrl`이 항상 `null`로 내려가던 문제)

🤖 Generated with [Claude Code](https://claude.com/claude-code)