### PR TITLE
[Feature] 잘한점 오디오 구간 URL 반환

### DIFF
--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/dto/response/PositiveFeedbackResponse.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/dto/response/PositiveFeedbackResponse.java
@@ -15,7 +15,14 @@ public record PositiveFeedbackResponse(
                 segment.end(),
                 segment.goodPoint(),
                 null,
-                audioUrl
+                toSegmentUrl(audioUrl, segment)
         );
+    }
+
+    private static String toSegmentUrl(String audioUrl, GoodSegment segment) {
+        if (audioUrl == null || segment.start() == null || segment.end() == null) {
+            return audioUrl;
+        }
+        return audioUrl + "#t=" + segment.start() + "," + segment.end();
     }
 }


### PR DESCRIPTION
## 변경 사항
- `PositiveFeedbackResponse`의 `audioUrl`에 Media Fragment(`#t=start,end`)를 붙여 반환
- 예: `https://...presigned-url...#t=12.5,20.3` → HTML5 `<audio>` 등 Media Fragments를 지원하는 플레이어에서 해당 발화 구간만 재생
- `audioUrl` 또는 `start`/`end`가 null이면 원본 URL을 그대로 반환하도록 방어 처리

## 변경 이유
- 잘한점(긍정 피드백) 항목마다 전체 녹음 URL이 동일하게 내려가고 있어, 클라이언트가 해당 구간을 바로 재생할 수 없었음
- `#` 이후 프래그먼트는 서버로 전송되지 않으므로 S3 presigned 서명에 영향 없음

## 테스트 방법
1. 훈련 기록 상세 조회 API(`GET /training-records/{recordId}`) 호출
2. `positiveFeedbacks[].audioUrl`이 `...#t={startSecond},{endSecond}` 형태인지 확인
3. 해당 URL을 브라우저 `<audio>` 태그로 재생 시 지정 구간만 재생되는지 확인

## 관련 이슈
- closes #72

⚠️ base가 `feature/#69-recording-key-presigned-url`인 스택 PR입니다. #69 브랜치가 main에 머지되면 base를 main으로 변경해주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)