### PR TITLE
[Fix] 회원탈퇴 시 FK 제약으로 삭제 실패하던 문제 수정

### DIFF
--- a/src/main/java/ChickenMayoDeopbab/bada/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/attendance/repository/AttendanceRepository.java
@@ -3,9 +3,16 @@ package ChickenMayoDeopbab.bada.domain.attendance.repository;
 import ChickenMayoDeopbab.bada.domain.attendance.entity.Attendance;
 import ChickenMayoDeopbab.bada.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     boolean existsByAttendedDateAndUser(LocalDate attendedDate, Users user);
+
+    @Modifying(flushAutomatically = true)
+    @Query("delete from Attendance a where a.user = :user")
+    void deleteAllByUser(@Param("user") Users user);
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/callanxiety/repository/CallAnxietyStateRepository.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/callanxiety/repository/CallAnxietyStateRepository.java
@@ -5,6 +5,7 @@ import ChickenMayoDeopbab.bada.domain.user.entity.Users;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -24,4 +25,8 @@ public interface CallAnxietyStateRepository extends JpaRepository<CallAnxietySta
     Optional<CallAnxietyState> findByUserForUpdate(
             @Param("user") Users user
     );
+
+    @Modifying(flushAutomatically = true)
+    @Query("delete from CallAnxietyState state where state.user = :user")
+    void deleteByUser(@Param("user") Users user);
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/diagnosis/repository/DiagnosisResultRepository.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/diagnosis/repository/DiagnosisResultRepository.java
@@ -3,9 +3,16 @@ package ChickenMayoDeopbab.bada.domain.diagnosis.repository;
 import ChickenMayoDeopbab.bada.domain.diagnosis.entity.DiagnosisResult;
 import ChickenMayoDeopbab.bada.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface DiagnosisResultRepository extends JpaRepository<DiagnosisResult, Integer> {
     Optional<DiagnosisResult> findByUser(Users user);
+
+    @Modifying(flushAutomatically = true)
+    @Query("delete from DiagnosisResult d where d.user = :user")
+    void deleteAllByUser(@Param("user") Users user);
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingcallschedule/repository/TrainingCallScheduleRepository.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingcallschedule/repository/TrainingCallScheduleRepository.java
@@ -6,6 +6,9 @@ import ChickenMayoDeopbab.bada.domain.user.entity.Users;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -26,4 +29,8 @@ public interface TrainingCallScheduleRepository extends JpaRepository<TrainingCa
             TrainingCallScheduleStatus status,
             LocalDateTime now
     );
+
+    @Modifying(flushAutomatically = true)
+    @Query("delete from TrainingCallSchedule s where s.user = :user")
+    void deleteAllByUser(@Param("user") Users user);
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/repository/TrainingRecordRepository.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/repository/TrainingRecordRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface TrainingRecordRepository extends JpaRepository<TrainingRecord, Long> {
@@ -28,4 +29,6 @@ public interface TrainingRecordRepository extends JpaRepository<TrainingRecord, 
     Optional<TrainingRecord> findBySessionIdAndUser(String sessionId, Users user);
 
     int countByUser(Users user);
+
+    List<TrainingRecord> findAllByUser(Users user);
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/service/TrainingRecordService.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/service/TrainingRecordService.java
@@ -114,6 +114,22 @@ public class TrainingRecordService {
         trainingRecordRepository.delete(record);
     }
 
+    // 회원 탈퇴 시 해당 사용자의 훈련 기록과 외부 리소스(S3 녹음, AI 피드백)를 함께 정리
+    @Transactional
+    public void deleteAllByUser(Users user) {
+        List<TrainingRecord> records = trainingRecordRepository.findAllByUser(user);
+        if (records.isEmpty()) {
+            return;
+        }
+
+        for (TrainingRecord record : records) {
+            deleteRecordingQuietly(record.getRecordingKey());
+            deleteFeedbackQuietly(record.getSessionId());
+        }
+
+        trainingRecordRepository.deleteAll(records);
+    }
+
     @Transactional
     public AnxietyScoreResponse recordAnxietyScore(
             String sessionId,

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/user/service/UserService.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/user/service/UserService.java
@@ -1,10 +1,14 @@
 package ChickenMayoDeopbab.bada.domain.user.service;
 
 import ChickenMayoDeopbab.bada.domain.attendance.repository.AttendanceQueryRepository;
+import ChickenMayoDeopbab.bada.domain.callanxiety.repository.CallAnxietyStateRepository;
+import ChickenMayoDeopbab.bada.domain.attendance.repository.AttendanceRepository;
 import ChickenMayoDeopbab.bada.domain.diagnosis.entity.DiagnosisResult;
 import ChickenMayoDeopbab.bada.domain.diagnosis.exception.DiagnosisResultStatusCode;
 import ChickenMayoDeopbab.bada.domain.diagnosis.repository.DiagnosisResultRepository;
+import ChickenMayoDeopbab.bada.domain.trainingcallschedule.repository.TrainingCallScheduleRepository;
 import ChickenMayoDeopbab.bada.domain.trainingrecord.repository.TrainingRecordRepository;
+import ChickenMayoDeopbab.bada.domain.trainingrecord.service.TrainingRecordService;
 import ChickenMayoDeopbab.bada.domain.user.dto.request.SignUpRequest;
 import ChickenMayoDeopbab.bada.domain.user.dto.request.UpdateMyPageRequest;
 import ChickenMayoDeopbab.bada.domain.user.dto.response.MyPageResponse;
@@ -28,7 +32,11 @@ public class UserService {
     private final UsersRepository usersRepository;
     private final DiagnosisResultRepository diagnosisResultRepository;
     private final AttendanceQueryRepository attendanceQueryRepository;
+    private final AttendanceRepository attendanceRepository;
+    private final CallAnxietyStateRepository callAnxietyStateRepository;
     private final TrainingRecordRepository trainingRecordRepository;
+    private final TrainingRecordService trainingRecordService;
+    private final TrainingCallScheduleRepository trainingCallScheduleRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -41,12 +49,20 @@ public class UserService {
         redisTemplate.delete(request.email());
     }
 
+    // users를 FK로 참조하는 자식 데이터를 먼저 정리한 뒤 회원을 삭제한다.
     public void withdraw() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        Users user = usersRepository.findByUsername(auth.getName())
-                .orElseThrow(() -> new ApplicationException(UsersStatusCode.USER_NOT_FOUND));
+        Users user = getUserInfo();
+        Long userId = user.getUserId();
+
+        trainingRecordService.deleteAllByUser(user);
+        trainingCallScheduleRepository.deleteAllByUser(user);
+        attendanceRepository.deleteAllByUser(user);
+        callAnxietyStateRepository.deleteByUser(user);
+        diagnosisResultRepository.deleteAllByUser(user);
 
         usersRepository.delete(user);
+
+        redisTemplate.delete("refreshToken: " + userId);
     }
 
     public ApiResponse<MyPageResponse> myPage() {

--- a/src/test/java/ChickenMayoDeopbab/bada/domain/trainingrecord/service/TrainingRecordServiceTest.java
+++ b/src/test/java/ChickenMayoDeopbab/bada/domain/trainingrecord/service/TrainingRecordServiceTest.java
@@ -13,18 +13,22 @@ import ChickenMayoDeopbab.bada.global.exception.ApplicationException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class TrainingRecordServiceTest {
@@ -53,9 +57,13 @@ class TrainingRecordServiceTest {
     }
 
     private TrainingRecord record(String recordingKey) {
+        return record("sess-1", recordingKey);
+    }
+
+    private TrainingRecord record(String sessionId, String recordingKey) {
         return TrainingRecord.builder()
                 .user(user)
-                .sessionId("sess-1")
+                .sessionId(sessionId)
                 .recordingKey(recordingKey)
                 .build();
     }
@@ -128,5 +136,44 @@ class TrainingRecordServiceTest {
         verify(fileService, never()).deleteByKey(anyString());
         verify(feedbackCleanupPort).deleteBySessionId("sess-1");
         verify(trainingRecordRepository).delete(record);
+    }
+
+    @Test
+    void deleteAllByUserRemovesEveryRecordWithItsRecordingAndFeedback() {
+        TrainingRecord first = record("sess-1", "recordings/sess-1.wav");
+        TrainingRecord second = record("sess-2", "recordings/sess-2.wav");
+        List<TrainingRecord> records = List.of(first, second);
+        when(trainingRecordRepository.findAllByUser(user)).thenReturn(records);
+
+        service.deleteAllByUser(user);
+
+        InOrder order = inOrder(fileService, feedbackCleanupPort, trainingRecordRepository);
+        order.verify(fileService).deleteByKey("recordings/sess-1.wav");
+        order.verify(feedbackCleanupPort).deleteBySessionId("sess-1");
+        order.verify(fileService).deleteByKey("recordings/sess-2.wav");
+        order.verify(feedbackCleanupPort).deleteBySessionId("sess-2");
+        order.verify(trainingRecordRepository).deleteAll(records);
+    }
+
+    @Test
+    void deleteAllByUserWithoutRecordsTouchesNothing() {
+        when(trainingRecordRepository.findAllByUser(user)).thenReturn(List.of());
+
+        service.deleteAllByUser(user);
+
+        verify(trainingRecordRepository, never()).deleteAll(any());
+        verifyNoInteractions(fileService, feedbackCleanupPort);
+    }
+
+    @Test
+    void deleteAllByUserContinuesWhenExternalCleanupFails() {
+        List<TrainingRecord> records = List.of(record("sess-1", "recordings/sess-1.wav"));
+        when(trainingRecordRepository.findAllByUser(user)).thenReturn(records);
+        doThrow(new RuntimeException("s3 down")).when(fileService).deleteByKey(anyString());
+        doThrow(new RuntimeException("ai down")).when(feedbackCleanupPort).deleteBySessionId(anyString());
+
+        service.deleteAllByUser(user);
+
+        verify(trainingRecordRepository).deleteAll(records);
     }
 }

--- a/src/test/java/ChickenMayoDeopbab/bada/domain/user/service/UserServiceTest.java
+++ b/src/test/java/ChickenMayoDeopbab/bada/domain/user/service/UserServiceTest.java
@@ -1,0 +1,129 @@
+package ChickenMayoDeopbab.bada.domain.user.service;
+
+import ChickenMayoDeopbab.bada.domain.attendance.repository.AttendanceQueryRepository;
+import ChickenMayoDeopbab.bada.domain.attendance.repository.AttendanceRepository;
+import ChickenMayoDeopbab.bada.domain.callanxiety.repository.CallAnxietyStateRepository;
+import ChickenMayoDeopbab.bada.domain.diagnosis.repository.DiagnosisResultRepository;
+import ChickenMayoDeopbab.bada.domain.trainingcallschedule.repository.TrainingCallScheduleRepository;
+import ChickenMayoDeopbab.bada.domain.trainingrecord.repository.TrainingRecordRepository;
+import ChickenMayoDeopbab.bada.domain.trainingrecord.service.TrainingRecordService;
+import ChickenMayoDeopbab.bada.domain.user.entity.Users;
+import ChickenMayoDeopbab.bada.domain.user.exception.UsersStatusCode;
+import ChickenMayoDeopbab.bada.domain.user.repository.UsersRepository;
+import ChickenMayoDeopbab.bada.global.exception.ApplicationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class UserServiceTest {
+
+    private final UsersRepository usersRepository = mock(UsersRepository.class);
+    private final DiagnosisResultRepository diagnosisResultRepository = mock(DiagnosisResultRepository.class);
+    private final AttendanceQueryRepository attendanceQueryRepository = mock(AttendanceQueryRepository.class);
+    private final AttendanceRepository attendanceRepository = mock(AttendanceRepository.class);
+    private final CallAnxietyStateRepository callAnxietyStateRepository = mock(CallAnxietyStateRepository.class);
+    private final TrainingRecordRepository trainingRecordRepository = mock(TrainingRecordRepository.class);
+    private final TrainingRecordService trainingRecordService = mock(TrainingRecordService.class);
+    private final TrainingCallScheduleRepository trainingCallScheduleRepository =
+            mock(TrainingCallScheduleRepository.class);
+    private final BCryptPasswordEncoder bCryptPasswordEncoder = mock(BCryptPasswordEncoder.class);
+
+    @SuppressWarnings("unchecked")
+    private final RedisTemplate<String, String> redisTemplate = mock(RedisTemplate.class);
+
+    private final UserService service = new UserService(
+            usersRepository,
+            diagnosisResultRepository,
+            attendanceQueryRepository,
+            attendanceRepository,
+            callAnxietyStateRepository,
+            trainingRecordRepository,
+            trainingRecordService,
+            trainingCallScheduleRepository,
+            bCryptPasswordEncoder,
+            redisTemplate
+    );
+
+    private final Users user = mock(Users.class);
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void login() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("junha", null));
+        when(usersRepository.findByUsername("junha")).thenReturn(Optional.of(user));
+        when(user.getUserId()).thenReturn(7L);
+    }
+
+    @Test
+    void withdrawDeletesEveryChildRowBeforeTheUser() {
+        login();
+
+        service.withdraw();
+
+        InOrder order = inOrder(
+                trainingRecordService,
+                trainingCallScheduleRepository,
+                attendanceRepository,
+                callAnxietyStateRepository,
+                diagnosisResultRepository,
+                usersRepository
+        );
+        order.verify(trainingRecordService).deleteAllByUser(user);
+        order.verify(trainingCallScheduleRepository).deleteAllByUser(user);
+        order.verify(attendanceRepository).deleteAllByUser(user);
+        order.verify(callAnxietyStateRepository).deleteByUser(user);
+        order.verify(diagnosisResultRepository).deleteAllByUser(user);
+        order.verify(usersRepository).delete(user);
+    }
+
+    @Test
+    void withdrawRemovesRefreshToken() {
+        login();
+
+        service.withdraw();
+
+        verify(redisTemplate).delete("refreshToken: 7");
+    }
+
+    @Test
+    void withdrawWithoutMatchingUserThrowsNotFoundAndDeletesNothing() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("junha", null));
+        when(usersRepository.findByUsername("junha")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(service::withdraw)
+                .isInstanceOf(ApplicationException.class)
+                .extracting(ex -> ((ApplicationException) ex).getStatusCode())
+                .isEqualTo(UsersStatusCode.USER_NOT_FOUND);
+
+        verify(usersRepository, never()).delete(any());
+        verifyNoInteractions(
+                trainingRecordService,
+                trainingCallScheduleRepository,
+                attendanceRepository,
+                callAnxietyStateRepository,
+                diagnosisResultRepository
+        );
+        verify(redisTemplate, never()).delete(anyString());
+    }
+}


### PR DESCRIPTION
## 문제

`withdraw()`가 자식 데이터를 남긴 채 `users` 행을 바로 삭제해서, FK 제약 위반으로 회원탈퇴가 실패했습니다.

`users`를 FK로 참조하는 테이블은 5개입니다.

| 테이블 | FK 컬럼 |
|---|---|
| `training_records` | `user_id` |
| `training_call_schedules` | `user_id` |
| `attendances` | `userId` |
| `call_anxiety_state` | `user_id` |
| `diagnosis_results` | `userId` |

## 변경 사항

- 각 리포지토리에 사용자 단위 벌크 삭제 쿼리 추가 (`@Modifying(flushAutomatically = true)`)
- `withdraw()`에서 자식 데이터 5종을 먼저 정리한 뒤 `users` 삭제
- 훈련 기록은 `TrainingRecordService.deleteAllByUser()`로 위임해 S3 녹음과 FastAPI 피드백까지 함께 정리 (외부 리소스 삭제 실패는 로그만 남기고 진행)
- 탈퇴 후에도 남던 Redis `refreshToken` 제거

## 확인

- `./gradlew compileJava` 통과
- 자식 테이블을 다시 참조하는 손자 테이블은 없어 연쇄 삭제 대상 없음
- FastAPI 쪽 `feedback`, `voice_tremor_metric`, `scenario`의 `user_id`는 FK 제약이 없어 삭제를 막지 않음

## 남은 이슈

- 탈퇴와 동시에 같은 유저의 다른 요청(세션 종료 콜백, 출석 체크 등)이 자식 행을 새로 넣으면 여전히 FK 위반 가능성이 있습니다. 필요하면 `withdraw()` 시작 시 유저 행에 비관적 락을 거는 방식으로 후속 처리 제안드립니다.
- FastAPI의 커스텀 시나리오(`scenario.user_id`, `is_custom = true`)는 탈퇴해도 남습니다. FK 제약이 없어 오류는 없지만 별도 정리가 필요합니다.

Fixes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
