### PR TITLE
Feature/#94 checking bada payment demand

### DIFF
--- a/src/main/java/ChickenMayoDeopbab/bada/domain/paymentintent/controller/AdminPaymentIntentController.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/paymentintent/controller/AdminPaymentIntentController.java
@@ -1,0 +1,23 @@
+package ChickenMayoDeopbab.bada.domain.paymentintent.controller;
+
+import ChickenMayoDeopbab.bada.domain.paymentintent.dto.response.PaymentIntentSummaryResponse;
+import ChickenMayoDeopbab.bada.domain.paymentintent.service.PaymentIntentService;
+import ChickenMayoDeopbab.bada.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/statistics/payment-intents")
+@RequiredArgsConstructor
+public class AdminPaymentIntentController {
+    private final PaymentIntentService paymentIntentService;
+
+    @GetMapping("/summary")
+    public ApiResponse<PaymentIntentSummaryResponse> getSummary() {
+        return ApiResponse.ok(
+                paymentIntentService.getSummary()
+        );
+    }
+}

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/paymentintent/controller/PaymentIntentController.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/paymentintent/controller/PaymentIntentController.java
@@ -1,0 +1,32 @@
+package ChickenMayoDeopbab.bada.domain.paymentintent.controller;
+
+import ChickenMayoDeopbab.bada.domain.paymentintent.dto.response.PaymentIntentStatusResponse;
+import ChickenMayoDeopbab.bada.domain.paymentintent.service.PaymentIntentService;
+import ChickenMayoDeopbab.bada.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/payment-intents")
+@RequiredArgsConstructor
+public class PaymentIntentController {
+    private final PaymentIntentService paymentIntentService;
+
+    @PostMapping
+    public ApiResponse<PaymentIntentStatusResponse> register() {
+        return ApiResponse.ok(
+                paymentIntentService.register(),
+                "아직 결제 기능이 지원되지 않습니다. 마음껏 이용해 주세요."
+        );
+    }
+
+    @GetMapping("/me")
+    public ApiResponse<PaymentIntentStatusResponse> getMyStatus() {
+        return ApiResponse.ok(
+                paymentIntentService.getMyStatus()
+        );
+    }
+}

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/paymentintent/dto/response/PaymentIntentStatusResponse.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/paymentintent/dto/response/PaymentIntentStatusResponse.java
@@ -1,0 +1,6 @@
+package ChickenMayoDeopbab.bada.domain.paymentintent.dto.response;
+
+public record PaymentIntentStatusResponse(
+        boolean paymentIntended
+) {
+}

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/paymentintent/dto/response/PaymentIntentSummaryResponse.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/paymentintent/dto/response/PaymentIntentSummaryResponse.java
@@ -1,0 +1,10 @@
+package ChickenMayoDeopbab.bada.domain.paymentintent.dto.response;
+
+import java.math.BigDecimal;
+
+public record PaymentIntentSummaryResponse(
+        long paymentIntendedUserCount,
+        long totalUserCount,
+        BigDecimal paymentIntentRate
+) {
+}

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/paymentintent/service/PaymentIntentService.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/paymentintent/service/PaymentIntentService.java
@@ -1,0 +1,95 @@
+package ChickenMayoDeopbab.bada.domain.paymentintent.service;
+
+import ChickenMayoDeopbab.bada.domain.paymentintent.dto.response.PaymentIntentStatusResponse;
+import ChickenMayoDeopbab.bada.domain.paymentintent.dto.response.PaymentIntentSummaryResponse;
+import ChickenMayoDeopbab.bada.domain.session.enums.EndReason;
+import ChickenMayoDeopbab.bada.domain.trainingrecord.repository.TrainingRecordRepository;
+import ChickenMayoDeopbab.bada.domain.user.entity.Role;
+import ChickenMayoDeopbab.bada.domain.user.entity.Users;
+import ChickenMayoDeopbab.bada.domain.user.exception.UsersStatusCode;
+import ChickenMayoDeopbab.bada.domain.user.repository.UsersRepository;
+import ChickenMayoDeopbab.bada.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentIntentService {
+    private static final List<EndReason> EXCLUDED_END_REASONS = List.of(EndReason.ERROR, EndReason.NO_AUDIO);
+    private final UsersRepository usersRepository;
+    private final TrainingRecordRepository trainingRecordRepository;
+
+    @Transactional
+    public PaymentIntentStatusResponse register() {
+        Users user = getCurrentUser();
+        user.intendPayment();
+
+        return new PaymentIntentStatusResponse(
+                user.isPaymentIntended()
+        );
+    }
+
+    public PaymentIntentStatusResponse getMyStatus() {
+        Users user = getCurrentUser();
+
+        return new PaymentIntentStatusResponse(
+                user.isPaymentIntended()
+        );
+    }
+
+    public PaymentIntentSummaryResponse getSummary() {
+        long totalUserCount =
+                trainingRecordRepository.countDistinctTrainedUsers(
+                        Role.USER,
+                        EXCLUDED_END_REASONS
+                );
+
+        long paymentIntendedUserCount =
+                trainingRecordRepository.countDistinctPaymentIntendedUsers(
+                        Role.USER,
+                        EXCLUDED_END_REASONS
+                );
+
+        return new PaymentIntentSummaryResponse(
+                paymentIntendedUserCount,
+                totalUserCount,
+                calculateRate(paymentIntendedUserCount, totalUserCount)
+        );
+    }
+
+    private BigDecimal calculateRate(long intended, long total) {
+        if (total == 0) {
+            return null;
+        }
+
+        return BigDecimal.valueOf(intended)
+                .multiply(BigDecimal.valueOf(100))
+                .divide(
+                        BigDecimal.valueOf(total),
+                        2,
+                        RoundingMode.HALF_UP
+                );
+    }
+
+    private Users getCurrentUser() {
+        Authentication authentication =
+                SecurityContextHolder.getContext().getAuthentication();
+
+        return usersRepository.findByUsername(
+                        authentication.getName()
+                )
+                .orElseThrow(() ->
+                        new ApplicationException(
+                                UsersStatusCode.USER_NOT_FOUND
+                        )
+                );
+    }
+}

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/repository/TrainingRecordRepository.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/trainingrecord/repository/TrainingRecordRepository.java
@@ -3,6 +3,7 @@ package ChickenMayoDeopbab.bada.domain.trainingrecord.repository;
 import ChickenMayoDeopbab.bada.domain.adminstatistics.model.AppliedTrainingStatisticsRow;
 import ChickenMayoDeopbab.bada.domain.session.enums.EndReason;
 import ChickenMayoDeopbab.bada.domain.trainingrecord.entity.TrainingRecord;
+import ChickenMayoDeopbab.bada.domain.user.entity.Role;
 import ChickenMayoDeopbab.bada.domain.user.entity.Users;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
@@ -50,4 +52,29 @@ public interface TrainingRecordRepository extends JpaRepository<TrainingRecord, 
                  training.scoreSequence desc
         """)
     List<AppliedTrainingStatisticsRow> findAllAppliedForAdminStatistics();
+
+    @Query("""
+        select count(distinct training.user.userId)
+        from TrainingRecord training
+        where training.user.role = :role
+          and training.endReason not in :excludedEndReasons
+        """)
+    long countDistinctTrainedUsers(
+            @Param("role") Role role,
+            @Param("excludedEndReasons")
+            Collection<EndReason> excludedEndReasons
+    );
+
+    @Query("""
+        select count(distinct training.user.userId)
+        from TrainingRecord training
+        where training.user.role = :role
+          and training.user.paymentIntended = true
+          and training.endReason not in :excludedEndReasons
+        """)
+    long countDistinctPaymentIntendedUsers(
+            @Param("role") Role role,
+            @Param("excludedEndReasons")
+            Collection<EndReason> excludedEndReasons
+    );
 }

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/user/entity/Users.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/user/entity/Users.java
@@ -54,6 +54,10 @@ public class Users {
 
     private String providerId;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean paymentIntended = false;
+
 
     @PrePersist
     public void prePersist() {
@@ -87,5 +91,9 @@ public class Users {
         this.name = name;
         this.username = username;
         this.profileImage = s3Key;
+    }
+
+    public void intendPayment() {
+        this.paymentIntended = true;
     }
 }


### PR DESCRIPTION
## Task
- Users에 결제 의향 여부를 저장하는 paymentIntended 필드를 추가
- 결제 버튼 클릭 시 결제 의향을 true로 기록
- 결제 의향 비율은 유효한 훈련 기록이 있는 일반 사용자를 기준으로 계산
  - 결제 의향 사용자 수 / 유효한 훈련 기록이 있는 전체 사용자 수 × 100
- 관리자용 결제 의향 통계 API

## Issue
#94 