### PR TITLE
fix: 진단 결과가 여러 건인 사용자의 마이페이지 500 오류 수정

### DIFF
--- a/src/main/java/ChickenMayoDeopbab/bada/domain/diagnosis/repository/DiagnosisResultRepository.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/diagnosis/repository/DiagnosisResultRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface DiagnosisResultRepository extends JpaRepository<DiagnosisResult, Integer> {
-    Optional<DiagnosisResult> findByUser(Users user);
+    Optional<DiagnosisResult> findFirstByUserOrderByCreatedAtDesc(Users user);
 
     @Modifying(flushAutomatically = true)
     @Query("delete from DiagnosisResult d where d.user = :user")

--- a/src/main/java/ChickenMayoDeopbab/bada/domain/user/service/UserService.java
+++ b/src/main/java/ChickenMayoDeopbab/bada/domain/user/service/UserService.java
@@ -67,7 +67,7 @@ public class UserService {
 
     public ApiResponse<MyPageResponse> myPage() {
         Users user = getUserInfo();
-        DiagnosisResult diagnosisResult = diagnosisResultRepository.findByUser(user)
+        DiagnosisResult diagnosisResult = diagnosisResultRepository.findFirstByUserOrderByCreatedAtDesc(user)
                 .orElseThrow(() -> new ApplicationException(DiagnosisResultStatusCode.DIAGNOSIS_RESULT_NOT_FOUND));
         int totalTraining = trainingRecordRepository.countByUser(user);
         int attendanceCount = attendanceQueryRepository.getTotalAttendance(user);

--- a/src/test/java/ChickenMayoDeopbab/bada/domain/user/service/UserServiceTest.java
+++ b/src/test/java/ChickenMayoDeopbab/bada/domain/user/service/UserServiceTest.java
@@ -3,10 +3,14 @@ package ChickenMayoDeopbab.bada.domain.user.service;
 import ChickenMayoDeopbab.bada.domain.attendance.repository.AttendanceQueryRepository;
 import ChickenMayoDeopbab.bada.domain.attendance.repository.AttendanceRepository;
 import ChickenMayoDeopbab.bada.domain.callanxiety.repository.CallAnxietyStateRepository;
+import ChickenMayoDeopbab.bada.domain.diagnosis.entity.CallPhobiaLevel;
+import ChickenMayoDeopbab.bada.domain.diagnosis.entity.DiagnosisResult;
+import ChickenMayoDeopbab.bada.domain.diagnosis.exception.DiagnosisResultStatusCode;
 import ChickenMayoDeopbab.bada.domain.diagnosis.repository.DiagnosisResultRepository;
 import ChickenMayoDeopbab.bada.domain.trainingcallschedule.repository.TrainingCallScheduleRepository;
 import ChickenMayoDeopbab.bada.domain.trainingrecord.repository.TrainingRecordRepository;
 import ChickenMayoDeopbab.bada.domain.trainingrecord.service.TrainingRecordService;
+import ChickenMayoDeopbab.bada.domain.user.dto.response.MyPageResponse;
 import ChickenMayoDeopbab.bada.domain.user.entity.Users;
 import ChickenMayoDeopbab.bada.domain.user.exception.UsersStatusCode;
 import ChickenMayoDeopbab.bada.domain.user.repository.UsersRepository;
@@ -19,8 +23,11 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -125,5 +132,36 @@ class UserServiceTest {
                 diagnosisResultRepository
         );
         verify(redisTemplate, never()).delete(anyString());
+    }
+
+    @Test
+    void myPageReadsTheMostRecentDiagnosisResultWhenTheUserHasSeveral() {
+        login();
+        DiagnosisResult latest = DiagnosisResult.builder()
+                .user(user)
+                .level(CallPhobiaLevel.LEVEL_2)
+                .score(2.5)
+                .updatedAt(LocalDateTime.of(2026, 9, 1, 10, 0))
+                .build();
+        when(diagnosisResultRepository.findFirstByUserOrderByCreatedAtDesc(user))
+                .thenReturn(Optional.of(latest));
+
+        MyPageResponse response = service.myPage().data();
+
+        assertThat(response.level()).isEqualTo(CallPhobiaLevel.LEVEL_2);
+        assertThat(response.score()).isEqualTo(2.5);
+        assertThat(response.diagnosisDate()).isEqualTo(LocalDate.of(2026, 9, 1));
+    }
+
+    @Test
+    void myPageWithoutAnyDiagnosisResultThrowsNotFound() {
+        login();
+        when(diagnosisResultRepository.findFirstByUserOrderByCreatedAtDesc(user))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(service::myPage)
+                .isInstanceOf(ApplicationException.class)
+                .extracting(ex -> ((ApplicationException) ex).getStatusCode())
+                .isEqualTo(DiagnosisResultStatusCode.DIAGNOSIS_RESULT_NOT_FOUND);
     }
 }


### PR DESCRIPTION
진단 제출은 submitAnswers 호출마다 diagnosis_results 행을 새로 저장하므로 한 사용자에게 진단 결과가 여러 건 쌓인다. 그런데 마이페이지는
Optional<DiagnosisResult> findByUser(Users)로 조회해 두 번째 진단부터는 결과가 여러 건 반환되어 IncorrectResultSizeDataAccessException으로 500이 났다.

createdAt 내림차순 첫 행만 가져오도록 findFirstByUserOrderByCreatedAtDesc로 바꿔 항상 최신 진단 결과를 반환하게 했다.

### Issue
- #109 